### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Lightbox Changelog
 
+## 2.0.1 - 2025-01-10
+
+- Fixed: A bug when checking for an asset's `alt` attribute would cause the `titleAsCaption` config setting to be ignored.
+
 ## 2.0.0 - 2024-04-22
 
 - Updated: Added support for Craft 5.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dodecastudio/craft-lightbox",
   "description": "A simple, responsive, accessible and customisable lightbox gallery that integrates seamlessly with Craft CMS.",
   "type": "craft-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "proprietary",
   "keywords": [
     "craft",

--- a/src/services/LightboxService.php
+++ b/src/services/LightboxService.php
@@ -62,8 +62,8 @@ class LightboxService extends Component
         if ($type == "image") {
             // Get title
             $asset = $source;
-            $alt = $asset->isFieldEmpty('alt') ? '' : $asset['alt'];
-            $title = $settings['titleAsCaption'] ? $asset['title'] : $alt;
+            $alt = trim($asset['alt'] ?? '') === '' ? '' : $asset['alt'];
+            $title = $settings['titleAsCaption'] || $alt === '' ? $asset['title'] : $alt;
 
             // Transforms
             $srcset = null;
@@ -104,8 +104,8 @@ class LightboxService extends Component
             if ($source instanceof Asset) {
                 // Attributes object
                 $asset = $source;
-                $alt = $asset->isFieldEmpty('alt') ? '' : $asset['alt'];
-                $title = $settings['titleAsCaption'] ? $asset['title'] : $alt;
+                $alt = trim($asset['alt'] ?? '') === '' ? '' : $asset['alt'];
+                $title = $settings['titleAsCaption'] || $alt === '' ? $asset['title'] : $alt;
                 $attributesObject['aria']['label'] = Craft::t('lightbox', 'VIDEOASSET_CONTROL_LABEL', ['title' => $title]);
                 $attributesObject['data']['mimetype'] = $asset['mimeType'];
                 $attributesObject['data']['title'] = $title;

--- a/src/templates/_frontend/gallery.twig
+++ b/src/templates/_frontend/gallery.twig
@@ -10,8 +10,9 @@
 {% apply spaceless %}
 
 <div {{ attr(craft.lightbox.galleryAttrs(galleryTitle, galleryRef)) }}>
-{% for asset in assets %}  
-  {% set alt = settings.titleAsCaption ? asset.title : asset.alt is defined ? asset.alt : '' %}
+{% for asset in assets %}
+  {% set assetAlt = asset.alt is defined and asset.alt|trim != '' ? asset.alt : '' %}
+  {% set alt = settings.titleAsCaption or assetAlt == '' ? asset.title : assetAlt %}
   {% set srcsets = craft.lightbox.getGalleryImageSrcset(asset) %}
   <a href="{{asset.url}}" {{ attr(craft.lightbox.linkAttrs(asset, galleryTitle, galleryRef)) }}>
     {% if srcsets.srcset|length > 0 or srcsets.srcsetwebp|length > 0 %}


### PR DESCRIPTION
- Fixed: A bug when checking for an asset's `alt` attribute would cause the `titleAsCaption` config setting to be ignored. `isEmptyField` didn't seem to be working so this has been removed.